### PR TITLE
In the Luau version, fix buffer allocation for small uncompressible data

### DIFF
--- a/llz4.luau
+++ b/llz4.luau
@@ -7,6 +7,8 @@ local MISS_COUNTER_BITS = 6 -- Lower values = the step is incremented sooner
 local HASH_SHIFT = 32 - 16  -- 32 - # of bits in the hash
 local MAX_DISTANCE = 0xFFFF -- Maximum offset that can fit into two bytes
 
+local SMALL_DATA_GROWTH = 2
+local SMALL_DATA_THRESHOLD = 50
 local MAX_COMPRESSION_GROWTH = 1 + 1/250
 local DEFAULT_BUFFER_SIZE = 512 * 1024^1 -- 512 KiB
 local DEFAULT_MAX_BUFFER_SIZE = 2^31 -- BIG
@@ -58,7 +60,8 @@ local function compressBuffer(data, dataStart, dataLen, acceleration)
 	acceleration = checkAcceleration(acceleration, 4, "compressBuffer")
 
 	local hashTable = {}
-	local out, outNext = buffer.create(math.ceil(dataLen * MAX_COMPRESSION_GROWTH)), 0
+	local realGrowth = if dataLen <= SMALL_DATA_THRESHOLD then SMALL_DATA_GROWTH else MAX_COMPRESSION_GROWTH
+	local out, outNext = buffer.create(math.ceil(dataLen * realGrowth)), 0
 
 	local pos = dataStart -- 0-indexed
 	local nextUnencodedPos = pos -- Sometimes called the "anchor" in other implementations


### PR DESCRIPTION
For sufficiently small data that is entirely uncompressible, the expansion of the input is quite high. It can be up to 2x in the worst case (a single byte of input). This falls off quite quickly, but it's the absolute worst-case scenario. It isn't until we reach 50 bytes of unique input that the previous max growth ratio of 1.004x is the result.

While you could argue that it's really a bad idea to compress data of this nature and we should just catch errors, I also think it's a bad idea to throw an error when provided with a safe input. To that end, this PR adds a special-case for input sizes below 50 where it assumes a worst-case growth of 2x. I figure anyone that is running Luau can afford 50 extra bytes, so this seems reasonable. Alternatives include special-casing it multiple times (e.g. anything below 20, we use 2x and below 50 we use 1.1x) or just making the entire module less efficient. 

<details>
<summary>Click for a table on expansion up</summary>

| Input Size | Output Size | Growth Ratio |
|:-----------|:------------|:-------------|
|  1 |  2 | 2.0000 |
|  2 |  3 | 1.5000 |
|  3 |  4 | 1.3333 |
|  4 |  5 | 1.2500 |
|  5 |  6 | 1.2000 |
|  6 |  7 | 1.1666 |
|  7 |  8 | 1.1428 |
|  8 |  9 | 1.1250 |
|  9 | 10 | 1.1110 |
| 10 | 11 | 1.1000 |
| 11 | 12 | 1.0909 |
| 12 | 13 | 1.0833 |
| 13 | 14 | 1.0769 |
| 14 | 15 | 1.0714 |
| 15 | 17 | 1.1333 |
| 16 | 18 | 1.1250 |
| 17 | 19 | 1.1176 |
| 18 | 20 | 1.1111 |
| 19 | 21 | 1.1052 |
| 20 | 22 | 1.1000 |
| 21 | 23 | 1.0952 |
| 22 | 24 | 1.0909 |
| 23 | 25 | 1.0869 |
| 24 | 26 | 1.0833 |
| 25 | 27 | 1.0800 |
| 26 | 28 | 1.0769 |
| 27 | 29 | 1.0740 |
| 28 | 30 | 1.0714 |
| 29 | 31 | 1.0689 |
| 30 | 32 | 1.0666 |
| 31 | 33 | 1.0645 |
| 32 | 34 | 1.0625 |
| 33 | 35 | 1.0606 |
| 34 | 36 | 1.0588 |
| 35 | 37 | 1.0571 |
| 36 | 38 | 1.0555 |
| 37 | 39 | 1.0540 |
| 38 | 40 | 1.0526 |
| 39 | 41 | 1.0512 |
| 40 | 42 | 1.0500 |
| 41 | 43 | 1.0487 |
| 42 | 44 | 1.0476 |
| 43 | 45 | 1.0465 |
| 44 | 46 | 1.0454 |
| 45 | 47 | 1.0444 |
| 46 | 48 | 1.0434 |
| 47 | 49 | 1.0425 |
| 48 | 50 | 1.0416 |
| 49 | 51 | 1.0408 |
| 50 | 52 | 1.0400 |
| 51 | 53 | 1.0392 |
| 52 | 54 | 1.0384 |
| 53 | 55 | 1.0377 |
| 54 | 56 | 1.0370 |
| 55 | 57 | 1.0363 |

</details>
